### PR TITLE
fix(pwa): initialize icons on load failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [14.2.2] - 2026-01-19
+
+### Fixed
+
+- **PWA cache issue**: Schedule loading failed on iOS homescreen app due to aggressive caching
+  - On load failure, initialize lucide icons to allow menu access
+
 ## [14.2.1] - 2026-01-19
 
 ### Fixed

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -152,6 +152,9 @@ async function initApp() {
 	console.error(e);
 	alert('Fehler beim Laden der Trainingspläne. Aktualisiere die App oder prüfe den Webserver.');
 
+	// Initialize icons so menu is visible
+	lucide.createIcons();
+
 	// Hide splash screen and show main app so user can access menu (e.g., for reload)
 	const splash = document.getElementById('splash-screen');
 	if (splash) {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "Body Refactoring - Personal Training Tracker with Dynamic Scheduling",
 	"type": "project",
 	"license": "GPL-2.0-or-later",
-	"version": "14.2.1",
+	"version": "14.2.2",
 	"authors": [
 		{
 			"name": "Christoph Daum",


### PR DESCRIPTION
## Description

This pull request addresses a PWA caching issue affecting schedule loading on iOS when the app is installed to the homescreen. The main fix ensures that if loading fails due to aggressive caching, the app still initializes icons so the menu remains accessible, improving user experience and recoverability.

Bug fix for PWA cache issue:

* On schedule loading failure, the app now initializes lucide icons to ensure the menu is visible and accessible, even if the main content fails to load. This helps users reload or navigate the app despite the error.

Documentation and version updates:

* Updated the `CHANGELOG.md` to document the PWA cache issue fix and the workaround for menu access.
* Bumped the project version to `14.2.2` in `composer.json` to reflect the new patch release.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update (non-functional changes)
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] 🔧 Configuration change

## Related Issues

<!-- Link to related issues, e.g., "Fixes #123" or "Closes #456" -->

## Changes Made

<!-- List the specific changes made in this PR -->

- 

## Testing

<!-- Describe the testing you've done -->

- [ ] Tested locally
- [ ] Tested on mobile device (iOS/Android)
- [ ] Checked browser console for errors
- [ ] Tested with different workout scenarios

## Checklist

- [ ] I have commented my code where necessary
- [x] I have updated the CHANGELOG.md following [Keep a Changelog](https://keepachangelog.com/) format
- [ ] I have updated the documentation (if applicable)
- [ ] I have tested the rep counter feature (if modified)
- [ ] I have validated schedule JSON files (if modified)
- [ ] My changes generate no new errors or warnings
- [x] I have updated the version number in `composer.json` (if releasing) ✅

## Deployment Notes

<!-- Any special deployment considerations? -->

## Additional Context

<!-- Add any other context about the PR here -->

