### PR TITLE
v14.6.8: schedule update with bike alternative and Mon/Wed volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [14.6.8] - 2026-04-29
+
+### Added
+
+- **Schedule for 2026-04-29**: New baseline training schedule
+- **Bike alternative**: Added Fahrrad as alternative to Walkingpad on Tuesdays (3 sessions) and to walking options on Saturdays
 
 ## [14.6.7] - 2026-03-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Schedule for 2026-04-29**: New baseline training schedule
 - **Bike alternative**: Added Fahrrad as alternative to Walkingpad on Tuesdays (3 sessions) and to walking options on Saturdays
 
+### Changed
+
+- **Reps standardized to 15** across all rep-counter exercises: Butterfly decreased from 18, Latziehen/Brustpresse from 12, Adduktion/Heel Taps/Bird Dog/Woodchoppers from 10
+
 ## [14.6.7] - 2026-03-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [14.6.7] - 2026-03-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Reps standardized to 15** across all rep-counter exercises: Butterfly decreased from 18, Latziehen/Brustpresse from 12, Adduktion/Heel Taps/Bird Dog/Woodchoppers from 10
+- **Monday volume**: Added Dumbbell Lateral Raises and Farmer's Carry (both optional) to support calorie goal
+- **Wednesday volume**: Added Dumbbell Lateral Raises and Farmer's Carry to support calorie goal
 
 ## [14.6.7] - 2026-03-05
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "Body Refactoring - Personal Training Tracker with Dynamic Scheduling",
 	"type": "project",
 	"license": "GPL-2.0-or-later",
-	"version": "14.6.7",
+	"version": "14.6.8",
 	"authors": [
 		{
 			"name": "Christoph Daum",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bodyrefactoring",
-	"version": "14.6.7",
+	"version": "14.6.8",
 	"private": true,
 	"description": "Body Refactoring - Personal Training Tracker with Dynamic Scheduling",
 	"scripts": {

--- a/schedules/schedule-2026-04-29.json
+++ b/schedules/schedule-2026-04-29.json
@@ -255,37 +255,79 @@
 		},
 		{
 		"id": "ex_walking_1",
-		"type": "main",
-		"title": "Walkingpad (1/3)",
-		"desc": "Schritte sammeln",
-		"timers": [
+		"type": "alternatives",
+		"alternatives": [
 			{
-			"l": "30 Min",
-			"s": 1800
+			"title": "Walkingpad (1/3)",
+			"desc": "Schritte sammeln",
+			"timers": [
+				{
+				"l": "30 Min",
+				"s": 1800
+				}
+			]
+			},
+			{
+			"title": "Fahrrad (1/3)",
+			"desc": "Heimtrainer, lockere Belastung",
+			"timers": [
+				{
+				"l": "30 Min",
+				"s": 1800
+				}
+			]
 			}
 		]
 		},
 		{
 		"id": "ex_walking_2",
-		"type": "main",
-		"title": "Walkingpad (2/3)",
-		"desc": "Schritte sammeln",
-		"timers": [
+		"type": "alternatives",
+		"alternatives": [
 			{
-			"l": "30 Min",
-			"s": 1800
+			"title": "Walkingpad (2/3)",
+			"desc": "Schritte sammeln",
+			"timers": [
+				{
+				"l": "30 Min",
+				"s": 1800
+				}
+			]
+			},
+			{
+			"title": "Fahrrad (2/3)",
+			"desc": "Heimtrainer, lockere Belastung",
+			"timers": [
+				{
+				"l": "30 Min",
+				"s": 1800
+				}
+			]
 			}
 		]
 		},
 		{
 		"id": "ex_walking_3",
-		"type": "main",
-		"title": "Walkingpad (3/3)",
-		"desc": "Schritte sammeln",
-		"timers": [
+		"type": "alternatives",
+		"alternatives": [
 			{
-			"l": "30 Min",
-			"s": 1800
+			"title": "Walkingpad (3/3)",
+			"desc": "Schritte sammeln",
+			"timers": [
+				{
+				"l": "30 Min",
+				"s": 1800
+				}
+			]
+			},
+			{
+			"title": "Fahrrad (3/3)",
+			"desc": "Heimtrainer, lockere Belastung",
+			"timers": [
+				{
+				"l": "30 Min",
+				"s": 1800
+				}
+			]
 			}
 		]
 		},
@@ -907,6 +949,20 @@
 			{
 			"title": "Indoor Walk",
 			"desc": "Laufband oder Walkingpad",
+			"timers": [
+				{
+				"l": "45 Min",
+				"s": 2700
+				},
+				{
+				"l": "60 Min",
+				"s": 3600
+				}
+			]
+			},
+			{
+			"title": "Fahrrad",
+			"desc": "Outdoor-Tour. Statt Spaziergang.",
 			"timers": [
 				{
 				"l": "45 Min",

--- a/schedules/schedule-2026-04-29.json
+++ b/schedules/schedule-2026-04-29.json
@@ -187,6 +187,36 @@
 		}
 		},
 		{
+		"id": "ex_lateral_raises",
+		"type": "main",
+		"title": "Dumbbell Lateral Raises",
+		"desc": "3 x 15 Wdh. Beide Arme gleichzeitig seitlich heben.",
+		"weight": "2",
+		"defaultUnit": "KG",
+		"optional": true,
+		"repCounter": {
+			"sets": 3,
+			"reps": 15,
+			"restSeconds": 60,
+			"delayMilliseconds": 2500
+		}
+		},
+		{
+		"id": "ex_farmers_walk",
+		"type": "main",
+		"title": "Farmer's Carry",
+		"desc": "3 x 45s. Schwere Hanteln. Aufrecht gehen. Griffkraft & Core.",
+		"weight": "20",
+		"defaultUnit": "KG",
+		"optional": true,
+		"timers": [
+			{
+			"l": "3 Sätze",
+			"s": 45
+			}
+		]
+		},
+		{
 		"id": "cool_stretch",
 		"type": "alternatives",
 		"alternatives": [
@@ -532,6 +562,34 @@
 			"restSeconds": 60,
 			"delayMilliseconds": 2400
 		}
+		},
+		{
+		"id": "ex_lateral_raises",
+		"type": "main",
+		"title": "Dumbbell Lateral Raises",
+		"desc": "3 x 15 Wdh. Beide Arme gleichzeitig seitlich heben.",
+		"weight": "2",
+		"defaultUnit": "KG",
+		"repCounter": {
+			"sets": 3,
+			"reps": 15,
+			"restSeconds": 60,
+			"delayMilliseconds": 2500
+		}
+		},
+		{
+		"id": "ex_farmers_walk",
+		"type": "main",
+		"title": "Farmer's Carry",
+		"desc": "3 x 45s. Schwere Hanteln. Aufrecht gehen. Griffkraft & Core.",
+		"weight": "20",
+		"defaultUnit": "KG",
+		"timers": [
+			{
+			"l": "3 Sätze",
+			"s": 45
+			}
+		]
 		},
 		{
 		"id": "cool_foam_bws",

--- a/schedules/schedule-2026-04-29.json
+++ b/schedules/schedule-2026-04-29.json
@@ -1,0 +1,1045 @@
+{
+"version": 2,
+"days": [
+	{
+	"id": "mon",
+	"dayIndex": 1,
+	"name": "MONTAG",
+	"theme": "Ganzkörper Kraft & Balance",
+	"icon": "dumbbell",
+	"colorClass": "text-blue-400",
+	"bgClass": "bg-blue-500/10",
+	"details": [
+		{
+		"id": "warmup_row",
+		"type": "warmup",
+		"title": "Rudern",
+		"desc": "Aufwärmen",
+		"timers": [
+			{
+			"l": "5 Min",
+			"s": 300
+			},
+			{
+			"l": "7 Min",
+			"s": 420
+			},
+			{
+			"l": "10 Min",
+			"s": 600
+			}
+		]
+		},
+		{
+		"id": "ex_adduktion",
+		"type": "main",
+		"title": "Bein-Adduktion",
+		"desc": "4 Sätze (2x Links, 2x Rechts - Wechsel als Pause).",
+		"weight": "2",
+		"defaultUnit": "STUFE",
+		"repCounter": {
+			"sets": 4,
+			"reps": 10,
+			"restSeconds": 30,
+			"delayMilliseconds": 2500,
+			"bilateral": true
+		}
+		},
+		{
+		"id": "ex_bizeps",
+		"type": "main",
+		"title": "Bizeps Curls",
+		"desc": "3 x 15 Wdh",
+		"weight": "2",
+		"defaultUnit": "STUFE",
+		"repCounter": {
+			"sets": 3,
+			"reps": 15,
+			"restSeconds": 60,
+			"delayMilliseconds": 2500
+		}
+		},
+		{
+		"id": "ex_rudern",
+		"type": "main",
+		"title": "Rudern sitzend",
+		"desc": "3 x 15 Wdh (Volumen erhöht)",
+		"weight": "3",
+		"defaultUnit": "STUFE",
+		"repCounter": {
+			"sets": 3,
+			"reps": 15,
+			"restSeconds": 60,
+			"delayMilliseconds": 2300
+		}
+		},
+		{
+		"id": "ex_latziehen",
+		"type": "main",
+		"title": "Latziehen",
+		"desc": "3 x 12 Wdh",
+		"weight": "3",
+		"defaultUnit": "STUFE",
+		"repCounter": {
+			"sets": 3,
+			"reps": 12,
+			"restSeconds": 60,
+			"delayMilliseconds": 2750
+		}
+		},
+		{
+		"id": "ex_beinstrecken",
+		"type": "main",
+		"title": "Beinstrecken",
+		"desc": "3 x 15 Wdh (Tempo angepasst: 2.5s)",
+		"weight": "2",
+		"defaultUnit": "STUFE",
+		"repCounter": {
+			"sets": 3,
+			"reps": 15,
+			"restSeconds": 60,
+			"delayMilliseconds": 2500
+		}
+		},
+		{
+		"id": "ex_brustpresse",
+		"type": "main",
+		"title": "Brustpresse",
+		"desc": "3 x 12 Wdh",
+		"weight": "3",
+		"defaultUnit": "STUFE",
+		"repCounter": {
+			"sets": 3,
+			"reps": 12,
+			"restSeconds": 60,
+			"delayMilliseconds": 2500
+		}
+		},
+		{
+		"id": "ex_butterfly",
+		"type": "main",
+		"title": "Butterfly",
+		"desc": "3 x 18 Wdh",
+		"weight": "2",
+		"defaultUnit": "STUFE",
+		"repCounter": {
+			"sets": 3,
+			"reps": 18,
+			"restSeconds": 60,
+			"delayMilliseconds": 2200
+		}
+		},
+		{
+		"id": "ex_butter_rev",
+		"type": "main",
+		"title": "Butterfly Reverse",
+		"desc": "3 x 15 Wdh (Hintere Schulter)",
+		"weight": "2",
+		"defaultUnit": "STUFE",
+		"repCounter": {
+			"sets": 3,
+			"reps": 15,
+			"restSeconds": 60,
+			"delayMilliseconds": 2500
+		}
+		},
+		{
+		"id": "ex_facepulls",
+		"type": "main",
+		"title": "Face Pulls",
+		"desc": "3 x 15 Wdh. Seil zum Gesicht, Ellbogen hoch. Externe Rotation!",
+		"weight": "2",
+		"defaultUnit": "STUFE",
+		"repCounter": {
+			"sets": 3,
+			"reps": 15,
+			"restSeconds": 60,
+			"delayMilliseconds": 2200
+		}
+		},
+		{
+		"id": "ex_trizeps_seil",
+		"type": "main",
+		"title": "Trizeps Drücken (Seil)",
+		"desc": "3 x 15 Wdh. Ellbogen fixieren!",
+		"weight": "2",
+		"defaultUnit": "STUFE",
+		"repCounter": {
+			"sets": 3,
+			"reps": 15,
+			"restSeconds": 60,
+			"delayMilliseconds": 2500
+		}
+		},
+		{
+		"id": "ex_beinbeugen_kabel",
+		"type": "main",
+		"title": "Beinbeugen stehend (Kabel)",
+		"desc": "4 x 15 Wdh (2x Links, 2x Rechts). Ferse zum Po ziehen.",
+		"weight": "1",
+		"defaultUnit": "STUFE",
+		"repCounter": {
+			"sets": 4,
+			"reps": 15,
+			"restSeconds": 30,
+			"delayMilliseconds": 2250,
+			"bilateral": true
+		}
+		},
+		{
+		"id": "cool_stretch",
+		"type": "alternatives",
+		"alternatives": [
+			{
+			"title": "Full Body Stretch",
+			"desc": "Ganzer Körper dehnen",
+			"timers": [
+				{
+				"l": "3 Min",
+				"s": 180
+				},
+				{
+				"l": "5 Min",
+				"s": 300
+				}
+			]
+			},
+			{
+			"title": "Foam Rolling: Beine + Rücken",
+			"desc": "Oberschenkel, Waden, oberer Rücken. Nach schwerem Training.",
+			"timers": [
+				{
+				"l": "5 Min",
+				"s": 300
+				}
+			]
+			},
+			{
+			"title": "Cat-Cow + Child's Pose",
+			"desc": "Cat-Cow 2 Min, dann Child's Pose. Wirbelsäule mobilisieren.",
+			"timers": [
+				{
+				"l": "3 Min",
+				"s": 180
+				},
+				{
+				"l": "5 Min",
+				"s": 300
+				}
+			]
+			}
+		]
+		}
+	]
+	},
+	{
+	"id": "tue",
+	"dayIndex": 2,
+	"name": "DIENSTAG",
+	"theme": "Active Office (NEAT)",
+	"icon": "footprints",
+	"colorClass": "text-emerald-400",
+	"bgClass": "bg-emerald-500/10",
+	"details": [
+		{
+		"id": "warmup_mob",
+		"type": "warmup",
+		"title": "Joint Mobility",
+		"desc": "Beine ausschütteln",
+		"timers": [
+			{
+			"l": "2 Min",
+			"s": 120
+			}
+		]
+		},
+		{
+		"id": "ex_walking_1",
+		"type": "main",
+		"title": "Walkingpad (1/3)",
+		"desc": "Schritte sammeln",
+		"timers": [
+			{
+			"l": "30 Min",
+			"s": 1800
+			}
+		]
+		},
+		{
+		"id": "ex_walking_2",
+		"type": "main",
+		"title": "Walkingpad (2/3)",
+		"desc": "Schritte sammeln",
+		"timers": [
+			{
+			"l": "30 Min",
+			"s": 1800
+			}
+		]
+		},
+		{
+		"id": "ex_walking_3",
+		"type": "main",
+		"title": "Walkingpad (3/3)",
+		"desc": "Schritte sammeln",
+		"timers": [
+			{
+			"l": "30 Min",
+			"s": 1800
+			}
+		]
+		},
+		{
+		"id": "cool_hip",
+		"type": "alternatives",
+		"alternatives": [
+			{
+			"title": "Hüftbeuger Dehnen",
+			"desc": "Kniend oder stehend. Wichtig nach langem Sitzen\\!",
+			"timers": [
+				{
+				"l": "2 Min",
+				"s": 120
+				},
+				{
+				"l": "3 Min",
+				"s": 180
+				}
+			]
+			},
+			{
+			"title": "Figure-4 Stretch",
+			"desc": "Sitzend oder liegend. Öffnet Hüfte, dehnt Piriformis.",
+			"timers": [
+				{
+				"l": "2 Min",
+				"s": 120
+				}
+			]
+			},
+			{
+			"title": "Standing Quad + Hamstring",
+			"desc": "Stehend abwechselnd Oberschenkel vorne/hinten. Nach Walkingpad.",
+			"timers": [
+				{
+				"l": "3 Min",
+				"s": 180
+				}
+			]
+			}
+		]
+		}
+	]
+	},
+	{
+	"id": "wed",
+	"dayIndex": 3,
+	"name": "MITTWOCH",
+	"theme": "Kraft & Core Focus",
+	"icon": "dumbbell",
+	"colorClass": "text-blue-400",
+	"bgClass": "bg-blue-500/10",
+	"details": [
+		{
+		"id": "warmup_blaze",
+		"type": "warmup",
+		"title": "Blazepods",
+		"desc": "Reaction Drill",
+		"timers": [
+			{
+			"l": "5 Min",
+			"s": 300
+			}
+		]
+		},
+		{
+		"id": "ex_adduktion",
+		"type": "main",
+		"title": "Bein-Adduktion",
+		"desc": "4 Sätze (2x L, 2x R - Wechsel als Pause).",
+		"weight": "2",
+		"defaultUnit": "STUFE",
+		"repCounter": {
+			"sets": 4,
+			"reps": 10,
+			"restSeconds": 30,
+			"delayMilliseconds": 2500,
+			"bilateral": true
+		}
+		},
+		{
+		"id": "ex_beinstrecken",
+		"type": "main",
+		"title": "Beinstrecken",
+		"desc": "3 x 15 Wdh",
+		"weight": "2",
+		"defaultUnit": "STUFE",
+		"repCounter": {
+			"sets": 3,
+			"reps": 15,
+			"restSeconds": 60,
+			"delayMilliseconds": 2500
+		}
+		},
+		{
+		"id": "ex_latziehen",
+		"type": "main",
+		"title": "Latziehen",
+		"desc": "3 x 12 Wdh",
+		"weight": "3",
+		"defaultUnit": "STUFE",
+		"repCounter": {
+			"sets": 3,
+			"reps": 12,
+			"restSeconds": 60,
+			"delayMilliseconds": 2750
+		}
+		},
+		{
+		"id": "ex_rudern",
+		"type": "main",
+		"title": "Rudern sitzend",
+		"desc": "3 x 15 Wdh (Volumen erhöht)",
+		"weight": "3",
+		"defaultUnit": "STUFE",
+		"repCounter": {
+			"sets": 3,
+			"reps": 15,
+			"restSeconds": 60,
+			"delayMilliseconds": 2300
+		}
+		},
+		{
+		"id": "ex_facepulls",
+		"type": "main",
+		"title": "Face Pulls",
+		"desc": "3 x 15 Wdh. Seil zum Gesicht, Ellbogen hoch. Externe Rotation!",
+		"weight": "2",
+		"defaultUnit": "STUFE",
+		"repCounter": {
+			"sets": 3,
+			"reps": 15,
+			"restSeconds": 60,
+			"delayMilliseconds": 2200
+		}
+		},
+		{
+		"id": "ex_butterfly",
+		"type": "main",
+		"title": "Butterfly",
+		"desc": "3 x 18 Wdh",
+		"weight": "2",
+		"defaultUnit": "STUFE",
+		"repCounter": {
+			"sets": 3,
+			"reps": 18,
+			"restSeconds": 60,
+			"delayMilliseconds": 2200
+		}
+		},
+		{
+		"id": "ex_brustpresse",
+		"type": "main",
+		"title": "Brustpresse",
+		"desc": "3 x 12 Wdh",
+		"weight": "3",
+		"defaultUnit": "STUFE",
+		"repCounter": {
+			"sets": 3,
+			"reps": 12,
+			"restSeconds": 60,
+			"delayMilliseconds": 2500
+		}
+		},
+		{
+		"id": "ex_trizeps_seil",
+		"type": "main",
+		"title": "Trizeps Drücken (Seil)",
+		"desc": "3 x 15 Wdh. Ellbogen fixieren!",
+		"weight": "2",
+		"defaultUnit": "STUFE",
+		"repCounter": {
+			"sets": 3,
+			"reps": 15,
+			"restSeconds": 60,
+			"delayMilliseconds": 2500
+		}
+		},
+		{
+		"id": "ex_crunches_bank_90",
+		"type": "main",
+		"title": "Crunches (90° Ablage)",
+		"desc": "Rücken auf Matte, Waden 90° auf Bank. Bauch isolieren.",
+		"repCounter": {
+			"sets": 3,
+			"reps": 15,
+			"restSeconds": 60,
+			"delayMilliseconds": 2000
+		}
+		},
+		{
+		"id": "ex_pull_through",
+		"type": "main",
+		"title": "Cable Pull-Throughs",
+		"desc": "3 x 15 Wdh. Hüfte vorstrecken! Gluteus-Fokus.",
+		"weight": "2",
+		"defaultUnit": "STUFE",
+		"repCounter": {
+			"sets": 3,
+			"reps": 15,
+			"restSeconds": 60,
+			"delayMilliseconds": 2400
+		}
+		},
+		{
+		"id": "cool_foam_bws",
+		"type": "cool",
+		"title": "Foam: Oberer Rücken",
+		"desc": "Rolle quer. Hände hinter Kopf.</div><div class='flex gap-2 mt-2 flex-wrap'><a href='https://www.youtube.com/watch?v=hWHv-V5uNo4' target='_blank' class='system-timer-chip' style='background-color: #991b1b; color: #fef2f2; border: 1px solid #7f1d1d;'>▶️ Tutorial</a>",
+		"timers": [
+			{
+			"l": "2 Min",
+			"s": 120
+			}
+		]
+		},
+		{
+		"id": "cool_foam_quads",
+		"type": "cool",
+		"title": "Foam: Oberschenkel",
+		"desc": "Bauchlage (Plank) auf Rolle. Vorderseite langsam abfahren.</div><div class='flex gap-2 mt-2 flex-wrap'><a href='https://www.youtube.com/watch?v=J_-r4odY47M' target='_blank' class='system-timer-chip' style='background-color: #991b1b; color: #fef2f2; border: 1px solid #7f1d1d;'>▶️ Tutorial</a>",
+		"timers": [
+			{
+			"l": "2 Min",
+			"s": 120
+			}
+		]
+		},
+		{
+		"id": "cool_foam_glutes",
+		"type": "cool",
+		"title": "Foam: Gesäß",
+		"desc": "Auf Rolle sitzen, 4er-Form (Bein überschlagen).</div><div class='flex gap-2 mt-2 flex-wrap'><a href='https://www.youtube.com/watch?v=GSu4qZaJDgo' target='_blank' class='system-timer-chip' style='background-color: #991b1b; color: #fef2f2; border: 1px solid #7f1d1d;'>▶️ Tutorial</a>",
+		"timers": [
+			{
+			"l": "1 Min",
+			"s": 60
+			}
+		]
+		}
+	]
+	},
+	{
+	"id": "thu",
+	"dayIndex": 4,
+	"name": "DONNERSTAG",
+	"theme": "Active Recovery",
+	"icon": "gamepad-2",
+	"colorClass": "text-purple-400",
+	"bgClass": "bg-purple-500/10",
+	"details": [
+		{
+		"id": "warmup_arms",
+		"type": "warmup",
+		"title": "Armkreisen",
+		"desc": "Schultern lockern",
+		"timers": [
+			{
+			"l": "2 Min",
+			"s": 120
+			}
+		]
+		},
+		{
+		"id": "m_alt_group_thu",
+		"type": "alternatives",
+		"alternatives": [
+			{
+			"title": "Beat Saber (VR)",
+			"desc": "Level nach Gefühl wählen",
+			"timers": [
+				{
+				"l": "40 Min",
+				"s": 2400
+				}
+			]
+			},
+			{
+			"title": "Yoga",
+			"desc": "Rücken Fokus",
+			"timers": [
+				{
+				"l": "25 Min",
+				"s": 1500
+				}
+			]
+			}
+		]
+		},
+		{
+		"id": "cool_child",
+		"type": "alternatives",
+		"alternatives": [
+			{
+			"title": "Cat-Cow Stretch",
+			"desc": "Vierfüßlerstand. Wechsel zwischen Buckel und Hohlkreuz. Wirbelsäule mobilisieren.",
+			"timers": [
+				{
+				"l": "3 Min",
+				"s": 180
+				},
+				{
+				"l": "5 Min",
+				"s": 300
+				}
+			]
+			},
+			{
+			"title": "Foam Rolling: Oberer Rücken",
+			"desc": "Rolle quer unter Brustwirbelsäule. Gut nach Beat Saber.",
+			"timers": [
+				{
+				"l": "5 Min",
+				"s": 300
+				}
+			]
+			},
+			{
+			"title": "Supine Twist + Happy Baby",
+			"desc": "Rückenlage: Knie zur Seite drehen (2 Min/Seite), dann Happy Baby (1 Min). Lendenwirbelsäule entlasten.",
+			"timers": [
+				{
+				"l": "5 Min",
+				"s": 300
+				}
+			]
+			}
+		]
+		}
+	]
+	},
+	{
+	"id": "fri",
+	"dayIndex": 5,
+	"name": "FREITAG",
+	"theme": "Core & Cable Strength",
+	"icon": "dumbbell",
+	"colorClass": "text-pink-400",
+	"bgClass": "bg-pink-500/10",
+	"details": [
+		{
+		"id": "warmup_row",
+		"type": "warmup",
+		"title": "Rudern",
+		"desc": "Aufwärmen",
+		"timers": [
+			{
+			"l": "5 Min",
+			"s": 300
+			}
+		]
+		},
+		{
+		"id": "ex_incline_plank",
+		"type": "main",
+		"title": "Incline Plank (Bank)",
+		"desc": "Hände auf Bank, Körper gerade.",
+		"weight": "3",
+		"defaultUnit": "STUFE",
+		"timers": [
+			{
+			"l": "30s",
+			"s": 30
+			},
+			{
+			"l": "45s",
+			"s": 45
+			},
+			{
+			"l": "60s",
+			"s": 60
+			}
+		]
+		},
+		{
+		"id": "ex_knee_plank",
+		"type": "main",
+		"title": "Knee Plank",
+		"desc": "Knie am Boden, Körper gerade. Progression zu Full Plank!",
+		"timers": [
+			{
+			"l": "30s",
+			"s": 30
+			},
+			{
+			"l": "45s",
+			"s": 45
+			},
+			{
+			"l": "60s",
+			"s": 60
+			}
+		]
+		},
+		{
+		"id": "ex_crunches_bank_90",
+		"type": "main",
+		"title": "Crunches (90° Ablage)",
+		"desc": "3 x 15 Wdh. Rücken auf Matte, Beine auf Bank.",
+		"repCounter": {
+			"sets": 3,
+			"reps": 15,
+			"restSeconds": 60,
+			"delayMilliseconds": 2000
+		}
+		},
+		{
+		"id": "ex_heeltaps",
+		"type": "main",
+		"title": "Heel Taps",
+		"desc": "3 x 10 Wdh. Rücken flach! Knie 90°, nur Fersen senken.",
+		"repCounter": {
+			"sets": 3,
+			"reps": 10,
+			"restSeconds": 60,
+			"delayMilliseconds": 1800
+		}
+		},
+		{
+		"id": "ex_bird_dog",
+		"type": "main",
+		"title": "Bird Dog",
+		"desc": "3 x 10 Wdh pro Seite. Arm + Bein diagonal strecken. Rücken gerade!",
+		"repCounter": {
+			"sets": 6,
+			"reps": 10,
+			"restSeconds": 30,
+			"delayMilliseconds": 3000,
+			"bilateral": true
+		}
+		},
+		{
+		"id": "ex_latziehen",
+		"type": "main",
+		"title": "Latziehen",
+		"desc": "3 x 12 Wdh. Wie Mo/Mi - Rückenarbeit!",
+		"weight": "3",
+		"defaultUnit": "STUFE",
+		"repCounter": {
+			"sets": 3,
+			"reps": 12,
+			"restSeconds": 60,
+			"delayMilliseconds": 2750
+		}
+		},
+		{
+		"id": "ex_brustpresse",
+		"type": "main",
+		"title": "Brustpresse",
+		"desc": "3 x 12 Wdh",
+		"weight": "3",
+		"defaultUnit": "STUFE",
+		"repCounter": {
+			"sets": 3,
+			"reps": 12,
+			"restSeconds": 60,
+			"delayMilliseconds": 2500
+		}
+		},
+		{
+		"id": "ex_beinbeugen_kabel",
+		"type": "main",
+		"title": "Beinbeugen stehend (Kabel)",
+		"desc": "4 x 15 Wdh (2x Links, 2x Rechts). Ferse zum Po.",
+		"weight": "1",
+		"defaultUnit": "STUFE",
+		"repCounter": {
+			"sets": 4,
+			"reps": 15,
+			"restSeconds": 30,
+			"delayMilliseconds": 2250,
+			"bilateral": true
+		}
+		},
+		{
+		"id": "ex_cable_kickbacks",
+		"type": "main",
+		"title": "Cable Kickbacks",
+		"desc": "3 x 15 Wdh pro Seite. Kabel unten, Bein nach hinten strecken. Gluteus!",
+		"weight": "1",
+		"defaultUnit": "STUFE",
+		"repCounter": {
+			"sets": 6,
+			"reps": 15,
+			"restSeconds": 30,
+			"delayMilliseconds": 2500,
+			"bilateral": true
+		}
+		},
+		{
+		"id": "ex_woodchoppers",
+		"type": "main",
+		"title": "Dumbbell Woodchoppers",
+		"desc": "4 x 10 Wdh. Hantel diagonal führen. Rumpfrotation!",
+		"weight": "6",
+		"defaultUnit": "KG",
+		"repCounter": {
+			"sets": 4,
+			"reps": 10,
+			"restSeconds": 60,
+			"delayMilliseconds": 3400,
+			"bilateral": true
+		}
+		},
+		{
+		"id": "ex_lateral_raises",
+		"type": "main",
+		"title": "Dumbbell Lateral Raises",
+		"desc": "3 x 15 Wdh. Beide Arme gleichzeitig seitlich heben.",
+		"weight": "2",
+		"defaultUnit": "KG",
+		"repCounter": {
+			"sets": 3,
+			"reps": 15,
+			"restSeconds": 60,
+			"delayMilliseconds": 2500
+		}
+		},
+		{
+		"id": "ex_farmers_walk",
+		"type": "main",
+		"title": "Farmer's Carry",
+		"desc": "3 x 45s. Schwere Hanteln. Aufrecht gehen. Griffkraft & Core.",
+		"weight": "20",
+		"defaultUnit": "KG",
+		"timers": [
+			{
+			"l": "3 Sätze",
+			"s": 45
+			}
+		]
+		},
+		{
+		"id": "cool_upper",
+		"type": "alternatives",
+		"alternatives": [
+			{
+			"title": "Oberkörper Stretch",
+			"desc": "Schultern, Brust, Arme dehnen.",
+			"timers": [
+				{
+				"l": "5 Min",
+				"s": 300
+				}
+			]
+			},
+			{
+			"title": "Thread the Needle",
+			"desc": "Auf allen Vieren. Arm unter Körper fädeln. Thorax-Rotation.",
+			"timers": [
+				{
+				"l": "3 Min",
+				"s": 180
+				},
+				{
+				"l": "5 Min",
+				"s": 300
+				}
+			]
+			},
+			{
+			"title": "Doorway Chest Stretch + Tricep",
+			"desc": "Türrahmen für Brust, dann Arm hinterm Kopf für Trizeps.",
+			"timers": [
+				{
+				"l": "3 Min",
+				"s": 180
+				},
+				{
+				"l": "5 Min",
+				"s": 300
+				}
+			]
+			}
+		]
+		}
+	]
+	},
+	{
+	"id": "sat",
+	"dayIndex": 6,
+	"name": "SAMSTAG",
+	"theme": "Endurance & Kondition",
+	"icon": "footprints",
+	"colorClass": "text-green-400",
+	"bgClass": "bg-green-500/10",
+	"details": [
+		{
+		"id": "warmup_mob",
+		"type": "warmup",
+		"title": "Mobilisation",
+		"desc": "Schulterkreisen, Hüfte öffnen",
+		"timers": [
+			{
+			"l": "3 Min",
+			"s": 180
+			}
+		]
+		},
+		{
+		"id": "ex_walk",
+		"type": "alternatives",
+		"alternatives": [
+			{
+			"title": "Nature Walk",
+			"desc": "Draußen im Naturschutzgebiet. Kombinierbar mit Einkaufen!",
+			"timers": [
+				{
+				"l": "45 Min",
+				"s": 2700
+				},
+				{
+				"l": "60 Min",
+				"s": 3600
+				}
+			]
+			},
+			{
+			"title": "Indoor Walk",
+			"desc": "Laufband oder Walkingpad",
+			"timers": [
+				{
+				"l": "45 Min",
+				"s": 2700
+				},
+				{
+				"l": "60 Min",
+				"s": 3600
+				}
+			]
+			}
+		]
+		},
+		{
+		"id": "ex_rowing_intervals",
+		"type": "main",
+		"title": "Rudern Intervalle",
+		"desc": "1 Min Belastung, 1 Min Pause. 5 Runden. Nur wenn Spaziergang max. 60 Min war. Bei langem Gehen weglassen.",
+		"timers": [
+			{
+			"l": "10 Min",
+			"s": 600
+			}
+		]
+		},
+		{
+		"id": "cool_calves",
+		"type": "alternatives",
+		"alternatives": [
+			{
+			"title": "Waden & Hüfte dehnen",
+			"desc": "Klassisch nach langem Gehen. Waden-Stretch + Hüftbeuger.",
+			"timers": [
+				{
+				"l": "5 Min",
+				"s": 300
+				}
+			]
+			},
+			{
+			"title": "Downward Dog + Runners Lunge",
+			"desc": "Down Dog 2 Min (Waden), dann Runners Lunge pro Seite (Hüfte).",
+			"timers": [
+				{
+				"l": "5 Min",
+				"s": 300
+				},
+				{
+				"l": "7 Min",
+				"s": 420
+				}
+			]
+			},
+			{
+			"title": "Foam Rolling: Waden + IT Band",
+			"desc": "Nach Rudern-Intervallen. 3 Min Waden, 2 Min IT Band.",
+			"timers": [
+				{
+				"l": "5 Min",
+				"s": 300
+				}
+			]
+			}
+		]
+		}
+	]
+	},
+	{
+	"id": "sun",
+	"dayIndex": 0,
+	"name": "SONNTAG",
+	"theme": "Combat & VR Day",
+	"icon": "swords",
+	"colorClass": "text-orange-400",
+	"bgClass": "bg-orange-500/10",
+	"details": [
+		{
+		"id": "warmup_shadow",
+		"type": "warmup",
+		"title": "Schattenboxen",
+		"desc": "Locker bewegen",
+		"timers": [
+			{
+			"l": "3 Min",
+			"s": 180
+			}
+		]
+		},
+		{
+		"id": "ex_boxen",
+		"type": "main",
+		"title": "Boxsack & Pods",
+		"desc": "4-5 Runden mit Blazepods zwischen den Runden",
+		"timers": [
+			{
+			"l": "20 Min",
+			"s": 1200
+			},
+			{
+			"l": "25 Min",
+			"s": 1500
+			}
+		]
+		},
+		{
+		"id": "ex_vr",
+		"type": "main",
+		"title": "Beat Saber / VR",
+		"desc": "Kalorien verbrennen! Level nach Gefühl.",
+		"timers": [
+			{
+			"l": "30 Min",
+			"s": 1800
+			},
+			{
+			"l": "45 Min",
+			"s": 2700
+			}
+		]
+		},
+		{
+		"id": "cool_mental",
+		"type": "cool",
+		"title": "Mental Reset",
+		"desc": "Wochenplanung",
+		"timers": [
+			{
+			"l": "10 Min",
+			"s": 600
+			}
+		]
+		}
+	]
+	}
+]
+}

--- a/schedules/schedule-2026-04-29.json
+++ b/schedules/schedule-2026-04-29.json
@@ -39,7 +39,7 @@
 		"defaultUnit": "STUFE",
 		"repCounter": {
 			"sets": 4,
-			"reps": 10,
+			"reps": 15,
 			"restSeconds": 30,
 			"delayMilliseconds": 2500,
 			"bilateral": true
@@ -63,7 +63,7 @@
 		"id": "ex_rudern",
 		"type": "main",
 		"title": "Rudern sitzend",
-		"desc": "3 x 15 Wdh (Volumen erhöht)",
+		"desc": "3 x 15 Wdh",
 		"weight": "3",
 		"defaultUnit": "STUFE",
 		"repCounter": {
@@ -77,12 +77,12 @@
 		"id": "ex_latziehen",
 		"type": "main",
 		"title": "Latziehen",
-		"desc": "3 x 12 Wdh",
+		"desc": "3 x 15 Wdh",
 		"weight": "3",
 		"defaultUnit": "STUFE",
 		"repCounter": {
 			"sets": 3,
-			"reps": 12,
+			"reps": 15,
 			"restSeconds": 60,
 			"delayMilliseconds": 2750
 		}
@@ -105,12 +105,12 @@
 		"id": "ex_brustpresse",
 		"type": "main",
 		"title": "Brustpresse",
-		"desc": "3 x 12 Wdh",
+		"desc": "3 x 15 Wdh",
 		"weight": "3",
 		"defaultUnit": "STUFE",
 		"repCounter": {
 			"sets": 3,
-			"reps": 12,
+			"reps": 15,
 			"restSeconds": 60,
 			"delayMilliseconds": 2500
 		}
@@ -119,12 +119,12 @@
 		"id": "ex_butterfly",
 		"type": "main",
 		"title": "Butterfly",
-		"desc": "3 x 18 Wdh",
+		"desc": "3 x 15 Wdh",
 		"weight": "2",
 		"defaultUnit": "STUFE",
 		"repCounter": {
 			"sets": 3,
-			"reps": 18,
+			"reps": 15,
 			"restSeconds": 60,
 			"delayMilliseconds": 2200
 		}
@@ -403,7 +403,7 @@
 		"defaultUnit": "STUFE",
 		"repCounter": {
 			"sets": 4,
-			"reps": 10,
+			"reps": 15,
 			"restSeconds": 30,
 			"delayMilliseconds": 2500,
 			"bilateral": true
@@ -427,12 +427,12 @@
 		"id": "ex_latziehen",
 		"type": "main",
 		"title": "Latziehen",
-		"desc": "3 x 12 Wdh",
+		"desc": "3 x 15 Wdh",
 		"weight": "3",
 		"defaultUnit": "STUFE",
 		"repCounter": {
 			"sets": 3,
-			"reps": 12,
+			"reps": 15,
 			"restSeconds": 60,
 			"delayMilliseconds": 2750
 		}
@@ -441,7 +441,7 @@
 		"id": "ex_rudern",
 		"type": "main",
 		"title": "Rudern sitzend",
-		"desc": "3 x 15 Wdh (Volumen erhöht)",
+		"desc": "3 x 15 Wdh",
 		"weight": "3",
 		"defaultUnit": "STUFE",
 		"repCounter": {
@@ -469,12 +469,12 @@
 		"id": "ex_butterfly",
 		"type": "main",
 		"title": "Butterfly",
-		"desc": "3 x 18 Wdh",
+		"desc": "3 x 15 Wdh",
 		"weight": "2",
 		"defaultUnit": "STUFE",
 		"repCounter": {
 			"sets": 3,
-			"reps": 18,
+			"reps": 15,
 			"restSeconds": 60,
 			"delayMilliseconds": 2200
 		}
@@ -483,12 +483,12 @@
 		"id": "ex_brustpresse",
 		"type": "main",
 		"title": "Brustpresse",
-		"desc": "3 x 12 Wdh",
+		"desc": "3 x 15 Wdh",
 		"weight": "3",
 		"defaultUnit": "STUFE",
 		"repCounter": {
 			"sets": 3,
-			"reps": 12,
+			"reps": 15,
 			"restSeconds": 60,
 			"delayMilliseconds": 2500
 		}
@@ -739,10 +739,10 @@
 		"id": "ex_heeltaps",
 		"type": "main",
 		"title": "Heel Taps",
-		"desc": "3 x 10 Wdh. Rücken flach! Knie 90°, nur Fersen senken.",
+		"desc": "3 x 15 Wdh. Rücken flach! Knie 90°, nur Fersen senken.",
 		"repCounter": {
 			"sets": 3,
-			"reps": 10,
+			"reps": 15,
 			"restSeconds": 60,
 			"delayMilliseconds": 1800
 		}
@@ -751,10 +751,10 @@
 		"id": "ex_bird_dog",
 		"type": "main",
 		"title": "Bird Dog",
-		"desc": "3 x 10 Wdh pro Seite. Arm + Bein diagonal strecken. Rücken gerade!",
+		"desc": "3 x 15 Wdh pro Seite. Arm + Bein diagonal strecken. Rücken gerade!",
 		"repCounter": {
 			"sets": 6,
-			"reps": 10,
+			"reps": 15,
 			"restSeconds": 30,
 			"delayMilliseconds": 3000,
 			"bilateral": true
@@ -764,12 +764,12 @@
 		"id": "ex_latziehen",
 		"type": "main",
 		"title": "Latziehen",
-		"desc": "3 x 12 Wdh. Wie Mo/Mi - Rückenarbeit!",
+		"desc": "3 x 15 Wdh. Wie Mo/Mi - Rückenarbeit!",
 		"weight": "3",
 		"defaultUnit": "STUFE",
 		"repCounter": {
 			"sets": 3,
-			"reps": 12,
+			"reps": 15,
 			"restSeconds": 60,
 			"delayMilliseconds": 2750
 		}
@@ -778,12 +778,12 @@
 		"id": "ex_brustpresse",
 		"type": "main",
 		"title": "Brustpresse",
-		"desc": "3 x 12 Wdh",
+		"desc": "3 x 15 Wdh",
 		"weight": "3",
 		"defaultUnit": "STUFE",
 		"repCounter": {
 			"sets": 3,
-			"reps": 12,
+			"reps": 15,
 			"restSeconds": 60,
 			"delayMilliseconds": 2500
 		}
@@ -822,12 +822,12 @@
 		"id": "ex_woodchoppers",
 		"type": "main",
 		"title": "Dumbbell Woodchoppers",
-		"desc": "4 x 10 Wdh. Hantel diagonal führen. Rumpfrotation!",
+		"desc": "4 x 15 Wdh. Hantel diagonal führen. Rumpfrotation!",
 		"weight": "6",
 		"defaultUnit": "KG",
 		"repCounter": {
 			"sets": 4,
-			"reps": 10,
+			"reps": 15,
 			"restSeconds": 60,
 			"delayMilliseconds": 3400,
 			"bilateral": true


### PR DESCRIPTION
## Summary

New training schedule effective from 2026-04-29. Adds Fahrrad as an alternative
to Walkingpad/walking on Tue and Sat, standardizes all rep counters to 15 reps
per set, and adds Dumbbell Lateral Raises plus Farmer's Carry to Mon (optional)
and Wed to support the calorie goal.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Changelog

### Added

- **Schedule for 2026-04-29**: New baseline training schedule
- **Bike alternative**: Fahrrad as alternative to Walkingpad on Tuesdays (3 sessions) and to walking options on Saturdays

### Changed

- **Reps standardized to 15** across all rep-counter exercises: Butterfly decreased from 18, Latziehen/Brustpresse from 12, Adduktion/Heel Taps/Bird Dog/Woodchoppers from 10
- **Monday volume**: Added Dumbbell Lateral Raises and Farmer's Carry (both optional) to support calorie goal
- **Wednesday volume**: Added Dumbbell Lateral Raises and Farmer's Carry to support calorie goal

## Testing

- [ ] Tested locally
- [ ] Tested on mobile device (iOS/Android)
- [ ] Checked browser console for errors
- [ ] Tested with different workout scenarios

## Checklist

- [ ] I have commented my code where necessary
- [x] I have updated the CHANGELOG.md following [Keep a Changelog](https://keepachangelog.com/) format
- [ ] I have updated the documentation (if applicable)
- [ ] I have tested the rep counter feature (if modified)
- [x] I have validated schedule JSON files (if modified) ✅
- [ ] My changes generate no new errors or warnings
- [ ] I have updated the version number in \`composer.json\` (if releasing)