### PR TITLE
chore(stale): never auto-close stale items

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,10 +16,12 @@ jobs:
       - uses: actions/stale@v9
         with:
           # Timing (separate for issues and PRs)
+          # -1 is actions/stale's "never close" value: items are still
+          # labelled stale, but they are never closed automatically.
           days-before-issue-stale: 30
-          days-before-issue-close: 14
+          days-before-issue-close: -1
           days-before-pr-stale: 14
-          days-before-pr-close: 14
+          days-before-pr-close: -1
 
           # Labels
           stale-issue-label: 'stale'
@@ -33,11 +35,11 @@ jobs:
           # Messages
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not had
-            recent activity. It will be closed in 14 days if no further activity occurs.
+            recent activity. It will not be closed automatically.
             If this issue is still relevant, please add a label or comment.
           stale-pr-message: >
             This PR has been automatically marked as stale because it has not had
-            recent activity. It will be closed in 14 days if no further activity occurs.
+            recent activity. It will not be closed automatically.
             If this PR is still relevant, please comment or remove the stale label.
 
           # Operations per run (GitHub API rate limiting)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [14.6.9] - 2026-08-18
+
+### Changed
+
+- **Stalebot**: No longer auto-closes issues and PRs (`days-before-*-close: -1`); they are still marked stale after inactivity
+- **Stale messages**: Reworded to state that items are not closed automatically, dropping the 14-day closing notice
+
 ## [14.6.8] - 2026-04-29
 
 ### Added
@@ -1059,6 +1066,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - LocalStorage for client-side data
 - Responsive design for mobile devices
 
+[14.6.9]: https://github.com/apermo/bodyrefactoring/compare/v14.6.8...v14.6.9
 [14.6.5]: https://github.com/apermo/bodyrefactoring/compare/v14.6.4...v14.6.5
 [14.6.4]: https://github.com/apermo/bodyrefactoring/compare/v14.6.3...v14.6.4
 [14.6.3]: https://github.com/apermo/bodyrefactoring/compare/v14.6.2...v14.6.3

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "Body Refactoring - Personal Training Tracker with Dynamic Scheduling",
 	"type": "project",
 	"license": "GPL-2.0-or-later",
-	"version": "14.6.8",
+	"version": "14.6.9",
 	"authors": [
 		{
 			"name": "Christoph Daum",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bodyrefactoring",
-	"version": "14.6.8",
+	"version": "14.6.9",
 	"private": true,
 	"description": "Body Refactoring - Personal Training Tracker with Dynamic Scheduling",
 	"scripts": {


### PR DESCRIPTION
The stale workflow currently closes inactive issues 14 days after they are
marked stale, and inactive PRs 14 days after theirs. Auto-closing is no longer
wanted: stale items should stay open so they remain visible and triageable.

## Changes

- `days-before-issue-close: 14` -> `-1`
- `days-before-pr-close: 14` -> `-1`

`-1` is the documented `actions/stale` value for "never close", with a comment
noting that.

- Reworded `stale-issue-message` and `stale-pr-message`. Both previously stated
  the item "will be closed in 14 days if no further activity occurs", which is
  no longer true. They now say it will not be closed automatically, keeping the
  existing "please add a label or comment" / "comment or remove the stale label"
  guidance.

## Unchanged

`days-before-issue-stale: 30` and `days-before-pr-stale: 14` (items are still
labelled stale), the `actions/stale@v9` version, the stale labels, the exempt
label lists, the cron schedule, and `operations-per-run: 30`.